### PR TITLE
Parse postfix operators

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -34,6 +34,8 @@ fn drive<'a>(filename: &'a str, src: &'a str) -> anyhow::Result<()> {
         anyhow::anyhow!("Parsing failed")
     })?;
 
+    println!("ast = {:#?}", ast);
+
     let resolver = Resolver::new("main");
 
     let mut typecheck = Typechecker::new(resolver);

--- a/src/sema/type_infer.rs
+++ b/src/sema/type_infer.rs
@@ -159,7 +159,10 @@ impl<'t> Typechecker {
     pub fn infer_expr(&self, value: &Spanned<Expr>) -> Return<Ty> {
         match &value.target {
             Expr::Literal(lit) => Ok(self.infer_literal(lit)),
-            Expr::QualifiedName(name) => self.lookup_name(name, value.location.clone()),
+            Expr::Member(_name) => {
+                todo!("Implement member lookup in infer_expr");
+                // self.lookup_name(name, value.location.clone()),
+            }
             Expr::BinOp(lhs, op, rhs) => self.infer_binop_expr(lhs, op, rhs),
             Expr::Array(elems) => self.infer_array_literal(elems),
             Expr::Cast(expr, ty) => {
@@ -189,8 +192,11 @@ impl<'t> Typechecker {
                 }))
             }
             Expr::ArrayIndex { array, index } => self.infer_array_like_index(array, index),
-            Expr::Call { callee, args } => match &callee.target {
-                Expr::QualifiedName(name) => self.infer_call_expr(&name, args),
+            Expr::Call { callee, args: _ } => match &callee.target {
+                Expr::Member(_name) => {
+                    todo!("Implement member lookup in infer_expr");
+                    // self.infer_call_expr(&name, args)
+                }
                 _ => panic!("Cannot call a non-function value"),
             },
             expr => unimplemented!("Unimplemented {:?}", expr),

--- a/src/sema/typecheck.rs
+++ b/src/sema/typecheck.rs
@@ -54,17 +54,18 @@ impl<'t> Typechecker {
         expr.clone().map_with_span(|texpr| match texpr {
             Expr::Literal(lit) => Ok(TExpr::Literal(lit.clone(), ty)),
 
-            Expr::QualifiedName(name) => {
-                let ty2 = self.lookup_name(&name, expr.location.clone())?;
-                if ty != ty2 {
-                    return Err(SemanticError::TypeMismatch {
-                        expected: ty,
-                        found: ty2,
-                        location: expr.location.clone(),
-                    });
-                }
+            Expr::Member(_name) => {
+                todo!("Member access not implemented yet");
+                // let ty2 = self.lookup_name(&name, expr.location.clone())?;
+                // if ty != ty2 {
+                //     return Err(SemanticError::TypeMismatch {
+                //         expected: ty,
+                //         found: ty2,
+                //         location: expr.location.clone(),
+                //     });
+                // }
 
-                Ok(TExpr::Name(name, ty))
+                // Ok(TExpr::Name(name, ty))
             }
             Expr::BinOp(lhs, op, rhs) => Ok(TExpr::BinOp(
                 Box::new(self.check_expr(&lhs)?),

--- a/src/syntax/ast.rs
+++ b/src/syntax/ast.rs
@@ -16,10 +16,17 @@ pub enum Literal {
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+pub struct Member {
+    pub target: Box<Spanned<Expr>>,
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
 pub enum Expr {
     // Primitive types
     Literal(Literal),
-    QualifiedName(String),
+    Ident(String),
+    Member(Member),
     Reference(Box<Spanned<Expr>>),
 
     // Operations

--- a/src/syntax/lexer.rs
+++ b/src/syntax/lexer.rs
@@ -5,6 +5,15 @@ use std::iter::Peekable;
 use logos::{Logos, SpannedIter};
 use serde::{Deserialize, Serialize};
 
+/// TODO:
+/// instead of storing the line number and column, we can store the start/end
+/// position only and then calculate the line/column when needed.  You'll need
+/// the original input string to do this.
+///
+/// We don't actually need the line number and column info of each node, we only
+/// need to calculate it when reporting an error for those couple of positions
+/// we care about.
+
 /// Report locations in the source code
 #[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Default)]
 pub struct SourceLoc {
@@ -136,6 +145,8 @@ pub enum TokenKind {
     #[regex(r"[ \t\f]+", logos::skip, priority = 2)]
     Whitespace,
 
+    // We're skipping newlines because, the enum parser (and probably other parts
+    // of the parser) don't know how to deal with newlines yet.
     #[regex(r"[\r\n]+", logos::skip)]
     NewLine,
 }


### PR DESCRIPTION
This PR updates the parser to handle parsing postfix operators for:
- member access, e.g. `foo.bar.baz`
- array access, e.g. `foo[bar]`
- function calls, e.g. `foo(bar)`

These postfix operators can be interleaved in any order, e.g. `foo[n]().bar().baz`.

TODO:
- [ ] fix type checking